### PR TITLE
Add backup-cleanup before each backup

### DIFF
--- a/tasks/bbr-backup-director/task.sh
+++ b/tasks/bbr-backup-director/task.sh
@@ -9,6 +9,10 @@ pushd director-backup-artifact
   ../binary/bbr director --host "${BOSH_ADDRESS}" \
   --username bbr \
   --private-key-path <(echo "${BBR_PRIVATE_KEY}") \
+  backup-cleanup 
+  ../binary/bbr director --host "${BOSH_ADDRESS}" \
+  --username bbr \
+  --private-key-path <(echo "${BBR_PRIVATE_KEY}") \
   backup
 
   tar -cvf director-backup.tar -- *

--- a/tasks/bbr-backup-ert/task.sh
+++ b/tasks/bbr-backup-ert/task.sh
@@ -7,6 +7,11 @@ pushd ert-backup-artifact
   --username "${BOSH_CLIENT}" \
   --deployment "${ERT_DEPLOYMENT_NAME}" \
   --ca-cert "${BOSH_CA_CERT_PATH}" \
+  backup-cleanup
+  ../binary/bbr deployment --target "${BOSH_ADDRESS}" \
+  --username "${BOSH_CLIENT}" \
+  --deployment "${ERT_DEPLOYMENT_NAME}" \
+  --ca-cert "${BOSH_CA_CERT_PATH}" \
   backup --with-manifest
 
   tar -cvf ert-backup.tar -- *


### PR DESCRIPTION
If a backup fails, BBR requires you to run a clean-up command or it errors with:
'cannot be backed up: directory /var/vcap/store/bbr-backup already exists'
This commit runs the clean-up command before every backup to ensure
it will be successful.