### PR TITLE
Get om from release page instead

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,13 @@
-FROM golang:1.8
+FROM ubuntu:16.04
 
 RUN \
   apt-get update && \
-  apt-get install -y jq sshuttle && \
+  apt-get install -y jq sshuttle curl wget ca-certificates && \
   rm -rf /var/lib/apt/lists/*
-
-RUN go get github.com/pivotal-cf/om
+RUN \
+  curl -s https://api.github.com/repos/pivotal-cf/om/releases/latest \
+    | grep "browser_download_url.*linux" \
+    | cut -d : -f 2,3 | tr -d \" \
+    | tr -d \" \
+    | wget -qi - -O /bin/om \
+  && chmod +x /bin/om

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,8 @@
-FROM ubuntu:16.04
-RUN \
-  apt-get update && \
-  apt-get install -y jq sshuttle curl wget ca-certificates && \
-  rm -rf /var/lib/apt/lists/*
-RUN \
-  curl -s https://api.github.com/repos/pivotal-cf/om/releases/latest \
-   | jq -r '.assets[] | select(.name=="om-linux") | .browser_download_url' \
-   | wget -qi - -O /bin/om \
-  && chmod +x /bin/om
+FROM alpine:3.7
+RUN apk --update --no-cache add bash jq python py2-pip curl wget \
+    && pip install sshuttle  \
+    && apk del py2-pip \
+    && curl -s https://api.github.com/repos/pivotal-cf/om/releases/latest \
+     | jq -r '.assets[] | select(.name=="om-linux") | .browser_download_url' \
+     | wget -qi - -O /bin/om \
+    && chmod +x /bin/om

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,10 @@
 FROM ubuntu:16.04
-
 RUN \
   apt-get update && \
   apt-get install -y jq sshuttle curl wget ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 RUN \
   curl -s https://api.github.com/repos/pivotal-cf/om/releases/latest \
-    | grep "browser_download_url.*linux" \
-    | cut -d : -f 2,3 | tr -d \" \
-    | tr -d \" \
-    | wget -qi - -O /bin/om \
+   | jq -r '.assets[] | select(.name=="om-linux") | .browser_download_url' \
+   | wget -qi - -O /bin/om \
   && chmod +x /bin/om


### PR DESCRIPTION
Installs om from releases page instead of through go, this way om is always pinned to a specific (latest) version. If this can be achieved using go get please educate me :)

With that the base image no longer requires golang, hence the switch to ubuntu:16.04.