### PR TITLE
Cleanup disk space used by this task

### DIFF
--- a/tasks/bbr-backup-director/task.sh
+++ b/tasks/bbr-backup-director/task.sh
@@ -12,4 +12,5 @@ pushd director-backup-artifact
   backup
 
   tar -cvf director-backup.tar -- *
+  rm -rf ${BOSH_ADDRESS}_*
 popd


### PR DESCRIPTION
After the tar has been created, remove the ${BOSH_IP} directory to free up disk space. Failure to do so causes double the disk space to be consumed. For larger PCF installations, this easily exceeds 80Gb and beyond.