### PR TITLE
update logic to wait for proxy connection to be established before ma…

### DIFF
--- a/pipeline.sample.yml
+++ b/pipeline.sample.yml
@@ -67,6 +67,7 @@ jobs:
       OPSMAN_URL: ((opsman-url))
       OPSMAN_USERNAME: ((opsman-username))
       OPSMAN_PASSWORD: ((opsman-password))
+      OPSMAN_PRIVATE_KEY: ((opsman-private-key))
     on_failure:
       task: bbr-cleanup-director
       tags:
@@ -77,6 +78,7 @@ jobs:
         OPSMAN_URL: ((opsman-url))
         OPSMAN_USERNAME: ((opsman-username))
         OPSMAN_PASSWORD: ((opsman-password))
+        OPSMAN_PRIVATE_KEY: ((opsman-private-key))
   - put: director-backup-bucket
     params:
       file: director-backup-artifact/director-backup.tar

--- a/scripts/export-director-metadata
+++ b/scripts/export-director-metadata
@@ -47,6 +47,8 @@ if [ ! -z ${OPSMAN_PRIVATE_KEY:+x} ]; then
   trap cleanup_socks_proxy EXIT
   export BOSH_ALL_PROXY=socks5://localhost:5000
   echo "Using BOSH_ALL_PROXY"
+  echo "sleeping for 5 secs to establish connection"
+  sleep 5s
 fi
 
 export BOSH_CLIENT


### PR DESCRIPTION
updating sample pipeline to include OPSMAN_PRIVATE_KEY for backing up director.  In addition, updating "export-director-metadata" to have a 5 sec delay before executing a bbr command through the proxy. It was discovered that not having the delay can result in a connection refused error. 