### PR TITLE
Fix args for backup-cleanup

### DIFF
--- a/scripts/deployment-backup-cleanup
+++ b/scripts/deployment-backup-cleanup
@@ -4,4 +4,4 @@
   --username "$BOSH_CLIENT" \
   --deployment "$DEPLOYMENT_NAME" \
   --ca-cert "$BOSH_CA_CERT_PATH" \
-  cleanup --with-manifest
+  backup-cleanup


### PR DESCRIPTION
The args for cleanup are wrong at least against the latest bbr release (1.2.8), this fixes the args.