### PR TITLE
Fix crash due to reference to undefined variable

### DIFF
--- a/scripts/om-cmd
+++ b/scripts/om-cmd
@@ -9,7 +9,7 @@ if ${skip_ssl}; then
     skip_ssl_flag="--skip-ssl-validation"
 fi
 
-if [ -z "${CLIENT_ID}" ] ; then
+if [ -z "${CLIENT_ID:-}" ] ; then
     echo "Using Ops Manager credentials"
     alias om_cmd='om ${skip_ssl_flag} --target "${OPSMAN_URL}" --username "${OPSMAN_USERNAME}" --password "${OPSMAN_PASSWORD}"'
 else


### PR DESCRIPTION
Because the scripts referring to `om-cmd` use `set -u`, the check for `$CLIENT_ID` needs to be guarded with a default.