### PR TITLE
Enable proxy configuation within bbr tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ There are a variety of storage resources such as [S3](https://github.com/concour
 
 ### HTTP Proxies
 
-BBR tasks for backing up deployments (pas, pks) leverage the BOSH API and will result in HTTP requests to the director. 
+BBR tasks for backing up deployments (pas, pks & ert) leverage the BOSH API and will result in HTTP requests to the director. 
 
-Setting the `SET_NO_PROXY` parameter on the tasks for `bbr-backup-pas`, `bbr-backup-pks` and `bbr-backup-pas-clusters` will result in a `NO_PROXY` environment variable being exported that contains the BOSH Director IP and OpsManager hostname. 
+Setting the `SET_NO_PROXY` parameter on the tasks will result in a `NO_PROXY` environment variable being exported that contains the BOSH Director IP. 
 
 ```yaml
 - task: bbr-backup-pas
@@ -74,8 +74,6 @@ Setting the `SET_NO_PROXY` parameter on the tasks for `bbr-backup-pas`, `bbr-bac
     OPSMAN_PRIVATE_KEY: ((opsman-private-key))    
     SET_NO_PROXY: true
 ```
-
-`HTTPS_PROXY` and `HTTP_PROXY` parameters are also available to be set and passed through to the container if a proxy is required. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ There are a variety of storage resources such as [S3](https://github.com/concour
 
 ### HTTP Proxies
 
-BBR tasks for backing up deployments (pas, pks) leverage the BOSH API and will result in HTTP requests to the director. 
+BBR tasks for backing up deployments (pas, pks & ert) leverage the BOSH API and will result in HTTP requests to the director. 
 
-Setting the `SET_NO_PROXY` parameter on the tasks for `bbr-backup-pas`, `bbr-backup-pks` and `bbr-backup-pas-clusters` will result in a `NO_PROXY` environment variable being exported that contains the BOSH Director IP and OpsManager hostname. 
+Setting the `SET_NO_PROXY` parameter on the tasks will result in a `NO_PROXY` environment variable being exported that contains the BOSH Director IP. 
 
 ```yaml
 - task: bbr-backup-pas
@@ -71,8 +71,6 @@ Setting the `SET_NO_PROXY` parameter on the tasks for `bbr-backup-pas`, `bbr-bac
     OPSMAN_PRIVATE_KEY: ((opsman-private-key))    
     SET_NO_PROXY: true
 ```
-
-`HTTPS_PROXY` and `HTTP_PROXY` parameters are also available to be set and passed through to the container if a proxy is required. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ Running regular backups (at least every 24 hours) and storing multiple copies of
 
 There are a variety of storage resources such as [S3](https://github.com/concourse/s3-resource) that can be used to move backups to storage. A list of Concourse resources can be found [here](https://concourse.ci/resource-types.html).
 
+### HTTP Proxies
+
+BBR tasks for backing up deployments (pas, pks) leverage the BOSH API and will result in HTTP requests to the director. 
+
+Setting the `SET_NO_PROXY` parameter on the tasks for `bbr-backup-pas`, `bbr-backup-pks` and `bbr-backup-pas-clusters` will result in a `NO_PROXY` environment variable being exported that contains the BOSH Director IP and OpsManager hostname. 
+
+```yaml
+- task: bbr-backup-pas
+  file: bbr-pipeline-tasks-repo/tasks/bbr-backup-pas/task.yml
+  params:
+    SKIP_SSL_VALIDATION: ((skip-ssl-validation))
+    OPSMAN_URL: ((opsman-url))
+    OPSMAN_USERNAME: ((opsman-username))
+    OPSMAN_PASSWORD: ((opsman-password))
+    OPSMAN_PRIVATE_KEY: ((opsman-private-key))    
+    SET_NO_PROXY: true
+```
+
+`HTTPS_PROXY` and `HTTP_PROXY` parameters are also available to be set and passed through to the container if a proxy is required. 
+
 ---
 
 ## Semantic Versioning

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This is a collection of [Concourse](https://concourse.ci) tasks for backing up a
 - [export-om-installation](tasks/export-om-installation/task.yml): Export Ops Manager installation settings
 - [bbr-backup-director](tasks/bbr-backup-director/task.yml): Run `bbr director backup`
 - [bbr-cleanup-director](tasks/bbr-cleanup-director/task.yml): Run `bbr director backup-cleanup`
+- [check-opsman-status](tasks/check-opsman-status/task.yml): Check `Apply changes` is not inflight before taking a backup. If it is, the task fails. This should prevent a backup from taking place. Please refer to the [example](examples/) pipelines to see how the task is used.
+
+
 
 ### DEPRECATED - ERT
 - [bbr-backup-ert](tasks/bbr-backup-ert/task.yml): Run `bbr deployment backup` for ERT

--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ Running regular backups (at least every 24 hours) and storing multiple copies of
 
 There are a variety of storage resources such as [S3](https://github.com/concourse/s3-resource) that can be used to move backups to storage. A list of Concourse resources can be found [here](https://concourse.ci/resource-types.html).
 
+### HTTP Proxies
+
+BBR tasks for backing up deployments (pas, pks) leverage the BOSH API and will result in HTTP requests to the director. 
+
+Setting the `SET_NO_PROXY` parameter on the tasks for `bbr-backup-pas`, `bbr-backup-pks` and `bbr-backup-pas-clusters` will result in a `NO_PROXY` environment variable being exported that contains the BOSH Director IP and OpsManager hostname. 
+
+```yaml
+- task: bbr-backup-pas
+  file: bbr-pipeline-tasks-repo/tasks/bbr-backup-pas/task.yml
+  params:
+    SKIP_SSL_VALIDATION: ((skip-ssl-validation))
+    OPSMAN_URL: ((opsman-url))
+    OPSMAN_USERNAME: ((opsman-username))
+    OPSMAN_PASSWORD: ((opsman-password))
+    OPSMAN_PRIVATE_KEY: ((opsman-private-key))    
+    SET_NO_PROXY: true
+```
+
+`HTTPS_PROXY` and `HTTP_PROXY` parameters are also available to be set and passed through to the container if a proxy is required. 
+
 ---
 
 ## Semantic Versioning

--- a/examples/pas-pipeline.yml
+++ b/examples/pas-pipeline.yml
@@ -36,6 +36,12 @@ jobs:
   - aggregate:
     - get: bbr-pipeline-tasks-repo
     - get: bbr-release
+  - task: check-opsman-status
+    tags:
+    - ((concourse-worker-tag))
+    file: bbr-pipeline-tasks-repo/tasks/check-opsman-status/task.yml
+    params:
+      <<: *opsman_credentials
   - task: extract-binary
     tags:
     - ((concourse-worker-tag))
@@ -61,6 +67,12 @@ jobs:
   - aggregate:
     - get: bbr-pipeline-tasks-repo
     - get: bbr-release
+  - task: check-opsman-status
+    tags:
+    - ((concourse-worker-tag))
+    file: bbr-pipeline-tasks-repo/tasks/check-opsman-status/task.yml
+    params:
+      <<: *opsman_credentials
   - task: extract-binary
     tags:
     - ((concourse-worker-tag))

--- a/examples/pks-pipeline.yml
+++ b/examples/pks-pipeline.yml
@@ -86,6 +86,12 @@ jobs:
     file: bbr-pipeline-tasks-repo/tasks/lock-pks/task.yml
     params:
       <<: *opsman_credentials
+  - task: check-opsman-status
+    tags:
+    - ((concourse-worker-tag))
+    file: bbr-pipeline-tasks-repo/tasks/check-opsman-status/task.yml
+    params:
+      <<: *opsman_credentials
   - task: extract-binary
     file: bbr-pipeline-tasks-repo/tasks/extract-bbr-binary/task.yml
   - aggregate:

--- a/examples/pks-pipeline.yml
+++ b/examples/pks-pipeline.yml
@@ -83,8 +83,6 @@ jobs:
     - get: bbr-release
     - get: bbr-pipeline-tasks-repo
   - task: check-opsman-status
-    tags:
-    - ((concourse-worker-tag))
     file: bbr-pipeline-tasks-repo/tasks/check-opsman-status/task.yml
     params:
       <<: *opsman_credentials

--- a/examples/pks-pipeline.yml
+++ b/examples/pks-pipeline.yml
@@ -82,14 +82,14 @@ jobs:
   - aggregate:
     - get: bbr-release
     - get: bbr-pipeline-tasks-repo
-  - task: lock-pks
-    file: bbr-pipeline-tasks-repo/tasks/lock-pks/task.yml
-    params:
-      <<: *opsman_credentials
   - task: check-opsman-status
     tags:
     - ((concourse-worker-tag))
     file: bbr-pipeline-tasks-repo/tasks/check-opsman-status/task.yml
+    params:
+      <<: *opsman_credentials
+  - task: lock-pks
+    file: bbr-pipeline-tasks-repo/tasks/lock-pks/task.yml
     params:
       <<: *opsman_credentials
   - task: extract-binary

--- a/scripts/export-director-metadata
+++ b/scripts/export-director-metadata
@@ -51,9 +51,9 @@ if [ ! -z ${OPSMAN_PRIVATE_KEY:+x} ]; then
   sleep 10s
 fi
 
-# Set NO_PROXY for BOSH Director and opsman host
+# Set NO_PROXY for BOSH Director
 if [ ! -z ${SET_NO_PROXY:+x} ] && [ $SET_NO_PROXY = true ]; then
-    export NO_PROXY="${BOSH_ENVIRONMENT},$(basename "${OPSMAN_URL}")"
+    export NO_PROXY="$NO_PROXY,${BOSH_ENVIRONMENT}")"
     echo "exporting NO_PROXY=${NO_PROXY}"
 fi
 

--- a/scripts/export-director-metadata
+++ b/scripts/export-director-metadata
@@ -51,6 +51,12 @@ if [ ! -z ${OPSMAN_PRIVATE_KEY:+x} ]; then
   sleep 10s
 fi
 
+# Set NO_PROXY for BOSH Director and opsman host
+if [ ! -z ${SET_NO_PROXY:+x} ] && [ $SET_NO_PROXY = true ]; then
+    export NO_PROXY="${BOSH_ENVIRONMENT},$(basename "${OPSMAN_URL}")"
+    echo "exporting NO_PROXY=${NO_PROXY}"
+fi
+
 export BOSH_CLIENT
 export BOSH_CLIENT_SECRET
 export BOSH_CA_CERT_PATH

--- a/scripts/export-director-metadata
+++ b/scripts/export-director-metadata
@@ -53,7 +53,7 @@ fi
 
 # Set NO_PROXY for BOSH Director
 if [ ! -z ${SET_NO_PROXY:+x} ] && [ $SET_NO_PROXY = true ]; then
-    export NO_PROXY="$NO_PROXY,${BOSH_ENVIRONMENT}")"
+    export NO_PROXY="${NO_PROXY},${BOSH_ENVIRONMENT}"
     echo "exporting NO_PROXY=${NO_PROXY}"
 fi
 

--- a/tasks/bbr-backup-ert/task.yml
+++ b/tasks/bbr-backup-ert/task.yml
@@ -37,3 +37,9 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config NO_PROXY for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  

--- a/tasks/bbr-backup-ert/task.yml
+++ b/tasks/bbr-backup-ert/task.yml
@@ -40,6 +40,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-backup-pas/task.yml
+++ b/tasks/bbr-backup-pas/task.yml
@@ -37,3 +37,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/bbr-backup-pas/task.yml
+++ b/tasks/bbr-backup-pas/task.yml
@@ -38,10 +38,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/bbr-backup-pas/task.yml
+++ b/tasks/bbr-backup-pas/task.yml
@@ -40,6 +40,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-backup-pks-clusters/task.yml
+++ b/tasks/bbr-backup-pks-clusters/task.yml
@@ -37,3 +37,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/bbr-backup-pks-clusters/task.yml
+++ b/tasks/bbr-backup-pks-clusters/task.yml
@@ -38,10 +38,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/bbr-backup-pks-clusters/task.yml
+++ b/tasks/bbr-backup-pks-clusters/task.yml
@@ -40,6 +40,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-backup-pks/task.yml
+++ b/tasks/bbr-backup-pks/task.yml
@@ -37,3 +37,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/bbr-backup-pks/task.yml
+++ b/tasks/bbr-backup-pks/task.yml
@@ -38,10 +38,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/bbr-backup-pks/task.yml
+++ b/tasks/bbr-backup-pks/task.yml
@@ -40,6 +40,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-cleanup-ert/task.yml
+++ b/tasks/bbr-cleanup-ert/task.yml
@@ -33,3 +33,9 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config NO_PROXY for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  

--- a/tasks/bbr-cleanup-ert/task.yml
+++ b/tasks/bbr-cleanup-ert/task.yml
@@ -36,6 +36,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-cleanup-pas/task.yml
+++ b/tasks/bbr-cleanup-pas/task.yml
@@ -36,6 +36,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-cleanup-pas/task.yml
+++ b/tasks/bbr-cleanup-pas/task.yml
@@ -33,3 +33,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/bbr-cleanup-pas/task.yml
+++ b/tasks/bbr-cleanup-pas/task.yml
@@ -34,10 +34,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/bbr-cleanup-pks-clusters/task.yml
+++ b/tasks/bbr-cleanup-pks-clusters/task.yml
@@ -36,6 +36,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-cleanup-pks-clusters/task.yml
+++ b/tasks/bbr-cleanup-pks-clusters/task.yml
@@ -33,3 +33,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/bbr-cleanup-pks-clusters/task.yml
+++ b/tasks/bbr-cleanup-pks-clusters/task.yml
@@ -34,10 +34,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/bbr-cleanup-pks/task.yml
+++ b/tasks/bbr-cleanup-pks/task.yml
@@ -36,6 +36,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/bbr-cleanup-pks/task.yml
+++ b/tasks/bbr-cleanup-pks/task.yml
@@ -33,3 +33,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/bbr-cleanup-pks/task.yml
+++ b/tasks/bbr-cleanup-pks/task.yml
@@ -34,10 +34,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/check-opsman-status/task.sh
+++ b/tasks/check-opsman-status/task.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scripts="$(dirname "$0")/../../scripts"
+
+# shellcheck source=../../scripts/om-cmd
+source "${scripts}/om-cmd"
+
+status="$(om_cmd installations --format json | jq .[0].status)"
+trimmed_status="$(xargs <<< "$status")"
+
+if [ "$trimmed_status" == "running" ]; then
+  echo "\"Apply Changes\" is in flight." 2>&1
+  exit 1
+fi
+
+echo "No \"Apply Changes\" in flight."

--- a/tasks/check-opsman-status/task.sh
+++ b/tasks/check-opsman-status/task.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 scripts="$(dirname "$0")/../../scripts"
 
 # shellcheck source=../../scripts/om-cmd
-source "${scripts}/om-cmd"
+source "${scripts}/om-cmd" > /dev/null
 
 status="$(om_cmd installations --format json | jq .[0].status)"
 trimmed_status="$(xargs <<< "$status")"
 
 if [ "$trimmed_status" == "running" ]; then
-  echo "\"Apply Changes\" is in flight." 2>&1
+  echo "\"Apply Changes\" is in flight." | tee /dev/stder
   exit 1
 fi
 

--- a/tasks/check-opsman-status/task.sh
+++ b/tasks/check-opsman-status/task.sh
@@ -11,7 +11,7 @@ status="$(om_cmd installations --format json | jq .[0].status)"
 trimmed_status="$(xargs <<< "$status")"
 
 if [ "$trimmed_status" == "running" ]; then
-  echo "\"Apply Changes\" is in flight." | tee /dev/stder
+  echo "\"Apply Changes\" is in flight." | tee /dev/stderr
   exit 1
 fi
 

--- a/tasks/check-opsman-status/task.yml
+++ b/tasks/check-opsman-status/task.yml
@@ -1,0 +1,34 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pcfplatformrecovery/bbr-pcf-pipeline-tasks
+    tag: final
+
+inputs:
+  - name: bbr-pipeline-tasks-repo
+
+outputs:
+
+run:
+  path: bbr-pipeline-tasks-repo/tasks/check-opsman-status/task.sh
+
+params:
+  # The Ops Manager URL, e.g. https://pcf.example.com
+  OPSMAN_URL:
+
+  # If true, SSL validation will be skipped when connecting to Ops Manager API
+  SKIP_SSL_VALIDATION: false
+
+  # Client credentials for Ops Manager API. If empty, user credentials will be used
+  CLIENT_ID:
+  CLIENT_SECRET:
+
+  # User credentials for Ops Manager API
+  OPSMAN_USERNAME:
+  OPSMAN_PASSWORD:
+
+  # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
+  OPSMAN_PRIVATE_KEY:

--- a/tasks/lock-pks/task.yml
+++ b/tasks/lock-pks/task.yml
@@ -31,3 +31,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/lock-pks/task.yml
+++ b/tasks/lock-pks/task.yml
@@ -32,10 +32,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/lock-pks/task.yml
+++ b/tasks/lock-pks/task.yml
@@ -34,6 +34,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   

--- a/tasks/unlock-pks/task.yml
+++ b/tasks/unlock-pks/task.yml
@@ -31,3 +31,11 @@ params:
   # The SSH private key for the Ops Manager VM
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
+
+  # Config HTTP Proxies for BOSH cli and OM
+  # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
+  #   with the BOSH Director IP and OPSMAN host
+  SET_NO_PROXY:
+  HTTPS_PROXY:
+  HTTP_PROXY:
+  

--- a/tasks/unlock-pks/task.yml
+++ b/tasks/unlock-pks/task.yml
@@ -32,10 +32,8 @@ params:
   # If provided, a SSH tunnel through the Ops Manager VM is created and used by bbr
   OPSMAN_PRIVATE_KEY:
 
-  # Config HTTP Proxies for BOSH cli and OM
+  # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
   #   with the BOSH Director IP and OPSMAN host
   SET_NO_PROXY:
-  HTTPS_PROXY:
-  HTTP_PROXY:
   

--- a/tasks/unlock-pks/task.yml
+++ b/tasks/unlock-pks/task.yml
@@ -34,6 +34,6 @@ params:
 
   # Config NO_PROXY for BOSH cli and OM
   # Setting SET_NO_PROXY: true results in NO_PROXY being exported 
-  #   with the BOSH Director IP and OPSMAN host
+  # with the BOSH Director IP
   SET_NO_PROXY:
   


### PR DESCRIPTION
* Added params for HTTPS_PROXY, HTTP_PROXY and a SET_NO_PROXY flag
* Logic to export `no_proxy` when SET_NO_PROXY has been explicitly set to true
* Updated README with example for SET_NO_PROXY