### PR TITLE
Fixed issue with NO_PROXY var not being set

### DIFF
--- a/scripts/export-director-metadata
+++ b/scripts/export-director-metadata
@@ -53,7 +53,7 @@ fi
 
 # Set NO_PROXY for BOSH Director
 if [ ! -z ${SET_NO_PROXY:+x} ] && [ $SET_NO_PROXY = true ]; then
-    export NO_PROXY="${NO_PROXY},${BOSH_ENVIRONMENT}"
+    export NO_PROXY="${BOSH_ENVIRONMENT},${NO_PROXY:=${no_proxy:=}}"
     echo "exporting NO_PROXY=${NO_PROXY}"
 fi
 


### PR DESCRIPTION
When `SET_NO_PROXY` is enabled and either `NO_PROXY` or `no_proxy` is not set from the bosh deployment the backup will fail. 