### PR TITLE
Use unversioned buckets when uploading artifacts to s3

### DIFF
--- a/examples/pas-pipeline.yml
+++ b/examples/pas-pipeline.yml
@@ -28,7 +28,7 @@ jobs:
       OPSMAN_PASSWORD: ((opsman-password))
   - put: om-backup-artifact
     params:
-      file: om-installation/installation.zip
+      file: om-installation/installation_*.zip
 
 - name: bbr-backup-pas
   serial: true
@@ -59,7 +59,7 @@ jobs:
         <<: *opsman_credentials
   - put: pas-backup-bucket
     params:
-      file: pas-backup-artifact/pas-backup.tar
+      file: pas-backup-artifact/pas-backup_*.tar
 
 - name: bbr-backup-director
   serial: true
@@ -92,7 +92,7 @@ jobs:
         <<: *opsman_credentials
   - put: director-backup-bucket
     params:
-      file: director-backup-artifact/director-backup.tar
+      file: director-backup-artifact/director-backup_*.tar
 
 resource_types:
 - name: pivnet
@@ -111,17 +111,17 @@ resources:
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: installation.zip
+    regexp: installation_(.*).zip
 - name: pas-backup-bucket
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: pas-backup.tar
+    regexp: pas-backup_(.*).tar
 - name: director-backup-bucket
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: director-backup.tar
+    regexp: director-backup_(.*).tar
 - name: bbr-release
   type: pivnet
   source:

--- a/examples/pks-pipeline.yml
+++ b/examples/pks-pipeline.yml
@@ -38,25 +38,25 @@ resources:
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: installation.zip
+    regexp: installation_(.*).zip
 
 - name: director-backup-bucket
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: director-backup.tar
+    regexp: director-backup_(.*).tar
 
 - name: pks-backup-bucket
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: pks-backup.tar
+    versioned_file: pks-backup_(.*).tar
 
 - name: pks-clusters-backup-bucket
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: pks-clusters-backup.tar
+    versioned_file: pks-clusters-backup_(.*).tar
 
 jobs:
 - name: export-om-installation
@@ -74,7 +74,7 @@ jobs:
       OPSMAN_PASSWORD: ((opsman-password))
   - put: om-backup-bucket
     params:
-      file: om-installation/installation.zip
+      file: om-installation/installation_*.zip
 
 - name: bbr-backup-pks-foundation
   serial: true
@@ -123,13 +123,13 @@ jobs:
   - in_parallel:
     - put: director-backup-bucket
       params:
-        file: director-backup-artifact/director-backup.tar
+        file: director-backup-artifact/director-backup_*.tar
     - put: pks-backup-bucket
       params:
-        file: pks-backup-artifact/pks-backup.tar
+        file: pks-backup-artifact/pks-backup_*.tar
     - put: pks-clusters-backup-bucket
       params:
-        file: pks-clusters-backup-artifact/pks-clusters-backup.tar
+        file: pks-clusters-backup-artifact/pks-clusters-backup_*.tar
   ensure:
     task: unlock-pks
     file: bbr-pipeline-tasks-repo/tasks/unlock-pks/task.yml

--- a/examples/pks-pipeline.yml
+++ b/examples/pks-pipeline.yml
@@ -50,13 +50,13 @@ resources:
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: pks-backup_(.*).tar
+    regexp: pks-backup_(.*).tar
 
 - name: pks-clusters-backup-bucket
   type: s3
   source:
     <<: *s3_credentials
-    versioned_file: pks-clusters-backup_(.*).tar
+    regexp: pks-clusters-backup_(.*).tar
 
 jobs:
 - name: export-om-installation

--- a/tasks/bbr-backup-director/task.sh
+++ b/tasks/bbr-backup-director/task.sh
@@ -3,9 +3,9 @@
 set -eu
 
 # shellcheck disable=SC1090
-source "$(dirname "$0")/../../scripts/export-director-metadata"
+source "$( dirname "$0" )/../../scripts/export-director-metadata"
 
-current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+current_date="$( date +"%Y-%m-%d-%H-%M-%S" )"
 
 pushd director-backup-artifact
   ../binary/bbr director --host "${BOSH_ENVIRONMENT}" \
@@ -13,6 +13,6 @@ pushd director-backup-artifact
     --private-key-path <(echo "${BOSH_PRIVATE_KEY}") \
     backup
 
-  tar -cvf director-backup_$current_date.tar --remove-files -- */*
+  tar -cvf "director-backup_${current_date}.tar" --remove-files -- */*
   # shellcheck disable=SC2086
 popd

--- a/tasks/bbr-backup-director/task.sh
+++ b/tasks/bbr-backup-director/task.sh
@@ -5,12 +5,14 @@ set -eu
 # shellcheck disable=SC1090
 source "$(dirname "$0")/../../scripts/export-director-metadata"
 
+current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+
 pushd director-backup-artifact
   ../binary/bbr director --host "${BOSH_ENVIRONMENT}" \
     --username "$BOSH_USERNAME" \
     --private-key-path <(echo "${BOSH_PRIVATE_KEY}") \
     backup
 
-  tar -cvf director-backup.tar --remove-files -- */*
+  tar -cvf director-backup_$current_date.tar --remove-files -- */*
   # shellcheck disable=SC2086
 popd

--- a/tasks/bbr-backup-ert/task.sh
+++ b/tasks/bbr-backup-ert/task.sh
@@ -2,20 +2,20 @@
 
 set -eu
 
-scripts="$(dirname "$0")/../../scripts"
+scripts="$( dirname "$0" )/../../scripts"
 
 echo "WARNING: bbr-backup-ert task is deprecated."
 echo "Please consider using bbr-backup-pas."
 
 # shellcheck disable=SC1090
-source "$scripts/export-director-metadata"
+source "${scripts}/export-director-metadata"
 # shellcheck disable=SC1090
-source "$scripts/export-cf-metadata"
+source "${scripts}/export-cf-metadata"
 
-current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+current_date="$( date +"%Y-%m-%d-%H-%M-%S" )"
 
 pushd ert-backup-artifact
   # shellcheck disable=SC1090
-  source "../$scripts/deployment-backup"
-  tar -cvf ert-backup_$current_date.tar --remove-files -- */*
+  source "../${scripts}/deployment-backup"
+  tar -cvf "ert-backup_${current_date}.tar" --remove-files -- */*
 popd

--- a/tasks/bbr-backup-ert/task.sh
+++ b/tasks/bbr-backup-ert/task.sh
@@ -12,8 +12,10 @@ source "$scripts/export-director-metadata"
 # shellcheck disable=SC1090
 source "$scripts/export-cf-metadata"
 
+current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+
 pushd ert-backup-artifact
   # shellcheck disable=SC1090
   source "../$scripts/deployment-backup"
-  tar -cvf ert-backup.tar --remove-files -- */*
+  tar -cvf ert-backup_$current_date.tar --remove-files -- */*
 popd

--- a/tasks/bbr-backup-pas/task.sh
+++ b/tasks/bbr-backup-pas/task.sh
@@ -2,18 +2,18 @@
 
 set -eu
 
-scripts="$(dirname "$0")/../../scripts"
+scripts="$( dirname "$0" )/../../scripts"
 
 # shellcheck disable=SC1090
-source "$scripts/export-director-metadata"
+source "${scripts}/export-director-metadata"
 # shellcheck disable=SC1090
-source "$scripts/export-cf-metadata"
+source "${scripts}/export-cf-metadata"
 
-current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+current_date="$( date +"%Y-%m-%d-%H-%M-%S" )"
 
 pushd pas-backup-artifact
   # shellcheck disable=SC1090
-  source "../$scripts/deployment-backup"
-  tar -cvf pas-backup_$current_date.tar --remove-files -- */*
+  source "../${scripts}/deployment-backup"
+  tar -cvf "pas-backup_${current_date}.tar" --remove-files -- */*
 popd
 

--- a/tasks/bbr-backup-pas/task.sh
+++ b/tasks/bbr-backup-pas/task.sh
@@ -9,9 +9,11 @@ source "$scripts/export-director-metadata"
 # shellcheck disable=SC1090
 source "$scripts/export-cf-metadata"
 
+current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+
 pushd pas-backup-artifact
   # shellcheck disable=SC1090
   source "../$scripts/deployment-backup"
-  tar -cvf pas-backup.tar --remove-files -- */*
+  tar -cvf pas-backup_$current_date.tar --remove-files -- */*
 popd
 

--- a/tasks/bbr-backup-pks-clusters/task.sh
+++ b/tasks/bbr-backup-pks-clusters/task.sh
@@ -9,6 +9,7 @@ source "$scripts/export-director-metadata"
 # shellcheck disable=SC1090
 source "$scripts/export-pks-metadata"
 
+current_date=$(date +"%Y-%m-%d-%H-%M-%S")
 
 pushd pks-clusters-backup-artifact
   # shellcheck disable=SC1090
@@ -20,5 +21,5 @@ pushd pks-clusters-backup-artifact
     --all-deployments \
     backup --with-manifest
 
-  tar -cvf pks-clusters-backup.tar --remove-files -- */*
+  tar -cvf pks-clusters-backup_$current_date.tar --remove-files -- */*
 popd

--- a/tasks/bbr-backup-pks-clusters/task.sh
+++ b/tasks/bbr-backup-pks-clusters/task.sh
@@ -2,14 +2,14 @@
 
 set -eu
 
-scripts="$(dirname "$0")/../../scripts"
+scripts="$( dirname "$0" )/../../scripts"
 
 # shellcheck disable=SC1090
-source "$scripts/export-director-metadata"
+source "${scripts}/export-director-metadata"
 # shellcheck disable=SC1090
-source "$scripts/export-pks-metadata"
+source "${scripts}/export-pks-metadata"
 
-current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+current_date="$( date +"%Y-%m-%d-%H-%M-%S" )"
 
 pushd pks-clusters-backup-artifact
   # shellcheck disable=SC1090
@@ -21,5 +21,5 @@ pushd pks-clusters-backup-artifact
     --all-deployments \
     backup --with-manifest
 
-  tar -cvf pks-clusters-backup_$current_date.tar --remove-files -- */*
+  tar -cvf "pks-clusters-backup_${current_date}.tar" --remove-files -- */*
 popd

--- a/tasks/bbr-backup-pks/task.sh
+++ b/tasks/bbr-backup-pks/task.sh
@@ -9,8 +9,10 @@ source "$scripts/export-director-metadata"
 # shellcheck disable=SC1090
 source "$scripts/export-pks-metadata"
 
+current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+
 pushd pks-backup-artifact
   # shellcheck disable=SC1090
   source "../$scripts/deployment-backup"
-  tar -cvf pks-backup.tar --remove-files -- */*
+  tar -cvf pks-backup_$current_date.tar --remove-files -- */*
 popd

--- a/tasks/bbr-backup-pks/task.sh
+++ b/tasks/bbr-backup-pks/task.sh
@@ -2,17 +2,17 @@
 
 set -eu
 
-scripts="$(dirname "$0")/../../scripts"
+scripts="$( dirname "$0" )/../../scripts"
 
 # shellcheck disable=SC1090
-source "$scripts/export-director-metadata"
+source "${scripts}/export-director-metadata"
 # shellcheck disable=SC1090
-source "$scripts/export-pks-metadata"
+source "${scripts}/export-pks-metadata"
 
-current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+current_date="$( date +"%Y-%m-%d-%H-%M-%S" )"
 
 pushd pks-backup-artifact
   # shellcheck disable=SC1090
-  source "../$scripts/deployment-backup"
-  tar -cvf pks-backup_$current_date.tar --remove-files -- */*
+  source "../${scripts}/deployment-backup"
+  tar -cvf "pks-backup_${current_date}.tar" --remove-files -- */*
 popd

--- a/tasks/export-om-installation/task.sh
+++ b/tasks/export-om-installation/task.sh
@@ -5,4 +5,6 @@ set -eu
 # shellcheck disable=SC1090
 source "$(dirname "$0")/../../scripts/om-cmd"
 
-om_cmd --request-timeout 7200 export-installation --output-file om-installation/installation.zip
+current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+
+om_cmd --request-timeout 7200 export-installation --output-file om-installation/installation_$current_date.zip

--- a/tasks/export-om-installation/task.sh
+++ b/tasks/export-om-installation/task.sh
@@ -5,6 +5,6 @@ set -eu
 # shellcheck disable=SC1090
 source "$(dirname "$0")/../../scripts/om-cmd"
 
-current_date=$(date +"%Y-%m-%d-%H-%M-%S")
+current_date="$( date +"%Y-%m-%d-%H-%M-%S" )"
 
-om_cmd --request-timeout 7200 export-installation --output-file om-installation/installation_$current_date.zip
+om_cmd --request-timeout 7200 export-installation --output-file "om-installation/installation_${current_date}.zip"


### PR DESCRIPTION
Currently the example pipelines is setup in such a way that it requires the bucket storing the s3 artifacts to have versioning enabled. This PR changes it so that unversioned method is used instead, each backup file will now having `_"Y-m-d-H-M-S"` timestamp added onto the end to ensure each file is unique