### PR TITLE
Always use the latest Ops Manager's Root CA

### DIFF
--- a/scripts/export-director-metadata
+++ b/scripts/export-director-metadata
@@ -21,7 +21,7 @@ if om_cmd curl -p /api/v0/deployed/director/credentials/uaa_bbr_client_credentia
   bosh_product_guid="$(om_cmd curl -p /api/v0/deployed/products | jq -r '.[] | select(.type=="p-bosh") | .guid')"
   BOSH_ENVIRONMENT="$(om_cmd curl -p "/api/v0/deployed/products/${bosh_product_guid}/static_ips" | jq -r .[0].ips[0])"
 
-  om_cmd curl -p /api/v0/certificate_authorities | jq -r .certificate_authorities[0].cert_pem > "$BOSH_CA_CERT_PATH"
+  om_cmd curl -p /api/v0/certificate_authorities | jq -r '.certificate_authorities | last.cert_pem' > "$BOSH_CA_CERT_PATH"
 else
   echo "Retreving Ops Manager client credentials for BOSH Director"
   om_cmd curl -p /api/v0/deployed/director/manifest > director_manifest.json


### PR DESCRIPTION
With this fix, `$BOSH_CA_CERT_PATH` always has the lastest Ops Manager's Root CA.

Ops Manager can have multiple Root CAs at the same time because deleting old CA is optional on the document until PAS v2.7.
When Ops Manager has multiple Root CAs, bbr tasks fail because `.certificate_authorities[0].cert_pem` returns the old CA.
FYI, jq's `last` works fine for an array which has only 1 element and multiple elements.
