### PR TITLE
Use latest stable docker-image-resource release

### DIFF
--- a/examples/pas-pipeline.yml
+++ b/examples/pas-pipeline.yml
@@ -86,6 +86,11 @@ resource_types:
   source:
     repository: pivotalcf/pivnet-resource
     tag: latest-final
+- name: docker-image-resource
+  type: docker-image
+  source:
+    repository: concourse/docker-image-resource
+    tag: v1.5
 
 resources:
 - name: bbr-pipeline-tasks-repo

--- a/examples/pks-pipeline.yml
+++ b/examples/pks-pipeline.yml
@@ -19,6 +19,11 @@ resource_types:
   source:
     repository: pivotalcf/pivnet-resource
     tag: latest-final
+- name: docker-image-resource
+  type: docker-image
+  source:
+    repository: concourse/docker-image-resource
+    tag: v1.5
 
 resources:
 - name: bbr-pipeline-tasks-repo


### PR DESCRIPTION
This is to remediate the docker hub rate limit issue.

https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/