### PR TITLE
Shared resources are causing the pipeline behave erratically

### DIFF
--- a/ci/pipelines/pas-pipeline-tasks/pipeline.yml
+++ b/ci/pipelines/pas-pipeline-tasks/pipeline.yml
@@ -369,6 +369,7 @@ resources:
 - name: tas-lts
   type: pcf-pool
   source:
+    workaround: pas-pipeline-tasks #! https://www.pivotaltracker.com/story/show/182523309
     api_token: ((toolsmiths.api_token))
     hostname: environments.toolsmiths.cf-app.com
     pool_name: us_2_11_lts2


### PR DESCRIPTION
[#182523309]

According to official Concourse docs:
https://concourse-ci.org/global-resources.html

>The basic concept of global resources is to share detected
>resource versions between all resources that have the same
>resource.type and resource.source configuration.

By adding a new non-existing field to resource.source we make
Concourse believe the resources are different, so it won't try
to share their versions' history. Also it won't affect the resource
semantics nor internal behaviour.